### PR TITLE
Upgrade to Go 1.12 runtime

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,4 @@
-runtime: go
-api_version: go1
+runtime: go112
 
 handlers:
 - url: /.*


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/standard/go112/go-differences